### PR TITLE
Two metoro exporter replicas by default

### DIFF
--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -5,7 +5,7 @@ exporter:
     podAnnotations: {}
     selectorLabels:
       app.kubernetes.io/name: "metoro-exporter"
-  replicas: 1
+  replicas: 2
   updateStrategy:
     type: "RollingUpdate"
   envVars:


### PR DESCRIPTION
HPA has a min of two replicas but our default number of replicas is one, aligning the values here