### PR TITLE
Only use auth if enabled

### DIFF
--- a/charts/metoro-exporter/templates/exporter_deployment.yaml
+++ b/charts/metoro-exporter/templates/exporter_deployment.yaml
@@ -75,11 +75,13 @@ spec:
                   {{- end }}
             - name: REDIS_URL
               value: {{printf "%s-master:%d" .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int)}}
+            {{- if .Values.redis.auth.enabled }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.redis.auth.existingSecret }}
                   key: password
+            {{- end }}
             - name: GIN_MODE
               value: release
             - name: SHOULD_DROP_METORO_DATA

--- a/charts/metoro-exporter/templates/node_agent_daemonset.yaml
+++ b/charts/metoro-exporter/templates/node_agent_daemonset.yaml
@@ -55,11 +55,13 @@ spec:
               value: {{ printf "http://%s:%d/v1/profiles" .Values.exporter.services.metoroExporter.name (.Values.exporter.services.metoroExporter.port | int) }}
             - name: REDIS_ADDRESS
               value: {{ printf "%s-master:%d" .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int) }}
+            {{- if .Values.redis.auth.enabled }}
             - name: REDIS_PASSWORD
               valueFrom:
                   secretKeyRef:
                     name: {{ .Values.redis.auth.existingSecret }}
                     key: password
+            {{- end }}
           {{ with .Values.nodeAgent.envVars.userDefined }}
           {{- . | toYaml | nindent 12 }}
           {{- end }}

--- a/charts/metoro-exporter/templates/redis_secret.yaml
+++ b/charts/metoro-exporter/templates/redis_secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.redis.auth.enabled }}
 # Redis auth secret
 apiVersion: v1
 kind: Secret
@@ -14,3 +15,4 @@ data:
   {{- else }}
   password: {{ $old_sec.data.password }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
If redis auth is disabled, the secret should not be deployed and all components should default to no auth with redis