### PR TITLE
Reduce go runtime overhead through max procs

### DIFF
--- a/charts/metoro-exporter/templates/exporter_deployment.yaml
+++ b/charts/metoro-exporter/templates/exporter_deployment.yaml
@@ -45,6 +45,11 @@ spec:
           image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.exporter.image.pullPolicy }}
           env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: "1"
             - name: VERSION
               value: {{ .Chart.AppVersion }}
             - name: HOST_IP

--- a/charts/metoro-exporter/templates/node_agent_daemonset.yaml
+++ b/charts/metoro-exporter/templates/node_agent_daemonset.yaml
@@ -47,6 +47,11 @@ spec:
           resources:
             {{- toYaml .Values.nodeAgent.resources | nindent 12 }}
           env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                 resource: limits.cpu
+                 divisor: "1"
             - name: DISABLE_LOG_PARSING
               value: {{ printf "\"%t\"" (not .Values.nodeAgent.logExport.enabled) }}
             - name: TRACES_ENDPOINT


### PR DESCRIPTION
GOMAXPROCS by default is the number of cpus on a host.

As the number of processes increases, the longer the goruntime spends deciding what / where to schedule.

This is a problem on especially large hosts, 48xlarge hosts for example: 192 cores. On those systems > 50% of the cpu time was being used up by the go scheduler. 

We now set GOMAXPROCS to the limit of the cpus we have as we can't use any more cores than that anyway. This significantly improves cpu usage on these large hosts.