### PR TITLE
Include missing tolerations for node agent

### DIFF
--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the Metoro Exporter
 
 type: application
 
-version: 0.460.0
+version: 0.461.0
 appVersion: 0.705.0
 
 dependencies:

--- a/charts/metoro-exporter/templates/node_agent_daemonset.yaml
+++ b/charts/metoro-exporter/templates/node_agent_daemonset.yaml
@@ -37,7 +37,11 @@ spec:
         {{- toYaml .Values.nodeAgent.scheduling.nodeSelector | nindent 8 }}
       {{- end }}
       tolerations:
+        {{- if .Values.nodeAgent.scheduling.tolerations }}
         {{- toYaml .Values.nodeAgent.scheduling.tolerations | nindent 8 }}
+        {{ else }}
+        - operator: Exists
+        {{- end }}
       priorityClassName: {{ .Values.nodeAgent.priorityClassName }}
       hostPID: true
       containers:

--- a/charts/metoro-exporter/templates/node_agent_daemonset.yaml
+++ b/charts/metoro-exporter/templates/node_agent_daemonset.yaml
@@ -37,7 +37,7 @@ spec:
         {{- toYaml .Values.nodeAgent.scheduling.nodeSelector | nindent 8 }}
       {{- end }}
       tolerations:
-        - operator: Exists
+        {{- toYaml .Values.nodeAgent.scheduling.tolerations | nindent 8 }}
       priorityClassName: {{ .Values.nodeAgent.priorityClassName }}
       hostPID: true
       containers:


### PR DESCRIPTION
Previously tolerations were ignored for the node agent.

This allows users to set tolerations that override the default of "all nodes"