### PR TITLE
Disable redis auth by default

### DIFF
--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the Metoro Exporter
 
 type: application
 
-version: 0.463.0
+version: 0.464.0
 appVersion: 0.919.0
 
 

--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the Metoro Exporter
 
 type: application
 
-version: 0.462.0
+version: 0.463.0
 appVersion: 0.705.0
 
 dependencies:

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -111,7 +111,7 @@ nodeAgent:
 redis:
   enabled: true
   auth:
-    enabled: true
+    enabled: false
     existingSecret: "redis-secret"
     existingSecretPasswordKey: "password"
   architecture: standalone


### PR DESCRIPTION
It seems like the autogenerated redis secret plays poorly with argocd. The contents of redis are not confidential anyway so we can just remove auth here.