### PR TITLE
Add pod disruption budgets

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,9 @@
+This repository stores the helm charts for metoro.
+The main helm chart is the metoro exporter. The metoro exporter consistents of the following components:
+* A daemonset called the metoro-node-agent. This runs on each host and collects information about the containers running there.
+  The daemonset collets metrics, traces and logs from the hosts containers and sends them to the metoro exporter.
+* A deployment called the metoro-exporer. This is a stateless component that takes request from the node agents and then sends the data to the metoro-hub.
+  The metoro hub is an out of cluster component which receives, stores the data and makes it available for querying. The default hub is in the cloud hosted by Metoro but its also possible to run the hub on prem.
+* Redis. A redis cluster handles storing some cluster metadata and acts as a replicated distributed queue for some communication of metadata between the node agents and the exporter.
+
+When making changes to this repository, you should be mindful of availability. There should always be at least one instance of the exporter running and there should be a quorum of redis pods available.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.iml
+.DS_Store

--- a/charts/metoro-exporter/templates/exporter_pdb.yaml
+++ b/charts/metoro-exporter/templates/exporter_pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.exporter.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.exporter.metadata.name }}
+  labels:
+    {{- include "metoro-exporter.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.exporter.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "metoro-exporter.selectorLabels" . | nindent 6 }}
+{{- end }} 

--- a/charts/metoro-exporter/templates/exporter_pdb.yaml
+++ b/charts/metoro-exporter/templates/exporter_pdb.yaml
@@ -4,10 +4,10 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ .Values.exporter.metadata.name }}
   labels:
-    {{- include "metoro-exporter.labels" . | nindent 4 }}
+    {{- include "metoro.labels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.exporter.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
-      {{- include "metoro-exporter.selectorLabels" . | nindent 6 }}
+      {{- include "metoro.selectorLabels" . | nindent 6 }}
 {{- end }} 

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -8,6 +8,10 @@ exporter:
   replicas: 2
   updateStrategy:
     type: "RollingUpdate"
+  # Pod Disruption Budget configuration
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
   envVars:
     mandatory:
       otlpUrl: "https://us-east.metoro.io/ingest/api/v1/otel"


### PR DESCRIPTION
This PR adds default support for pod disruption budgets.

Pod disruption budgets were added in k8s 1.21, which was released April 2021 - 4 years ago. We now feel that the vast majority of users should at least be on 1.21 so we can make this change.

This first change will add pod disruption budgets to the exporter to prevent an outage when nodes roll.