### PR TITLE
Add redis cluster to prevent outages with redis going down

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -7,3 +7,4 @@ The main helm chart is the metoro exporter. The metoro exporter consistents of t
 * Redis. A redis cluster handles storing some cluster metadata and acts as a replicated distributed queue for some communication of metadata between the node agents and the exporter.
 
 When making changes to this repository, you should be mindful of availability. There should always be at least one instance of the exporter running and there should be a quorum of redis pods available.
+Additionally, you should bear in mind that metoro can be ran on single node clusters for dev environments. Therefore we shouldn't fail in this case.

--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -17,3 +17,8 @@ dependencies:
     version: 20.1.6
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
+  - name: redis
+    alias: redisCluster
+    version: 20.1.6
+    repository: https://charts.bitnami.com/bitnami
+    condition: redisCluster.enabled

--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the Metoro Exporter
 
 type: application
 
-version: 0.464.0
+version: 0.465.0
 appVersion: 0.919.0
 
 

--- a/charts/metoro-exporter/templates/exporter_deployment.yaml
+++ b/charts/metoro-exporter/templates/exporter_deployment.yaml
@@ -79,7 +79,6 @@ spec:
                   key: {{ .Values.exporter.secret.externalSecret.secretKey }}
                   {{- end }}
             - name: REDIS_URL
-              # value: {{printf "redis+sentinel://%s-headless:%d/mymaster" .Values.redis.fullnameOverride (.Values.redis.sentinel.service.ports.redis | int)}}
               value: {{printf "%s-master:%d" .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int) }}
             {{- if .Values.redis.auth.enabled }}
             - name: REDIS_PASSWORD

--- a/charts/metoro-exporter/templates/exporter_deployment.yaml
+++ b/charts/metoro-exporter/templates/exporter_deployment.yaml
@@ -79,7 +79,7 @@ spec:
                   key: {{ .Values.exporter.secret.externalSecret.secretKey }}
                   {{- end }}
             - name: REDIS_URL
-              value: {{printf "%s-master:%d" .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int) }}
+              value: {{printf "%s-master:%d" .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int)}}
             {{- if .Values.redis.auth.enabled }}
             - name: REDIS_PASSWORD
               valueFrom:

--- a/charts/metoro-exporter/templates/exporter_deployment.yaml
+++ b/charts/metoro-exporter/templates/exporter_deployment.yaml
@@ -79,7 +79,8 @@ spec:
                   key: {{ .Values.exporter.secret.externalSecret.secretKey }}
                   {{- end }}
             - name: REDIS_URL
-              value: {{printf "%s-master:%d,%s-replicas:%d" .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int) .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int)}}
+              # value: {{printf "redis+sentinel://%s-headless:%d/mymaster" .Values.redis.fullnameOverride (.Values.redis.sentinel.service.ports.redis | int)}}
+              value: {{printf "%s-master:%d" .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int) }}
             {{- if .Values.redis.auth.enabled }}
             - name: REDIS_PASSWORD
               valueFrom:

--- a/charts/metoro-exporter/templates/exporter_deployment.yaml
+++ b/charts/metoro-exporter/templates/exporter_deployment.yaml
@@ -79,7 +79,7 @@ spec:
                   key: {{ .Values.exporter.secret.externalSecret.secretKey }}
                   {{- end }}
             - name: REDIS_URL
-              value: {{printf "%s-master:%d" .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int)}}
+              value: {{printf "%s-master:%d,%s-replicas:%d" .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int) .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int)}}
             {{- if .Values.redis.auth.enabled }}
             - name: REDIS_PASSWORD
               valueFrom:

--- a/charts/metoro-exporter/templates/exporter_deployment.yaml
+++ b/charts/metoro-exporter/templates/exporter_deployment.yaml
@@ -79,12 +79,22 @@ spec:
                   key: {{ .Values.exporter.secret.externalSecret.secretKey }}
                   {{- end }}
             - name: REDIS_URL
+              {{- if .Values.redis.enabled }}
               value: {{printf "%s-master:%d" .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int)}}
+              {{- else if .Values.redisCluster.enabled }}
+              value: {{printf "%s-master:%d" .Values.redisCluster.fullnameOverride (.Values.redisCluster.master.service.ports.redis | int)}}
+              {{- end }}
             {{- if .Values.redis.auth.enabled }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.redis.auth.existingSecret }}
+                  key: password
+            {{ else if .Values.redisCluster.auth.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redisCluster.auth.existingSecret }}
                   key: password
             {{- end }}
             - name: GIN_MODE

--- a/charts/metoro-exporter/templates/node_agent_daemonset.yaml
+++ b/charts/metoro-exporter/templates/node_agent_daemonset.yaml
@@ -65,12 +65,22 @@ spec:
             - name: PROFILES_ENDPOINT
               value: {{ printf "http://%s:%d/v1/profiles" .Values.exporter.services.metoroExporter.name (.Values.exporter.services.metoroExporter.port | int) }}
             - name: REDIS_ADDRESS
+              {{- if .Values.redis.enabled }}
               value: {{ printf "%s-master:%d" .Values.redis.fullnameOverride (.Values.redis.master.service.ports.redis | int) }}
+              {{- else if .Values.redisCluster.enabled }}
+              value: {{ printf "%s-master:%d" .Values.redisCluster.fullnameOverride (.Values.redisCluster.master.service.ports.redis | int) }}
+              {{- end }}
             {{- if .Values.redis.auth.enabled }}
             - name: REDIS_PASSWORD
               valueFrom:
                   secretKeyRef:
                     name: {{ .Values.redis.auth.existingSecret }}
+                    key: password
+            {{ else if .Values.redisCluster.auth.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.redisCluster.auth.existingSecret }}
                     key: password
             {{- end }}
           {{ with .Values.nodeAgent.envVars.userDefined }}

--- a/charts/metoro-exporter/templates/redis_secret.yaml
+++ b/charts/metoro-exporter/templates/redis_secret.yaml
@@ -16,3 +16,22 @@ data:
   password: {{ $old_sec.data.password }}
   {{- end }}
 {{- end }}
+
+{{- if .Values.redisCluster.auth.enabled }}
+# Redis auth secret
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.redisCluster.auth.existingSecret }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: redis
+type: Opaque
+data:
+  {{- $old_sec := lookup "v1" "Secret" .Release.Namespace .Values.redisCluster.auth.existingSecret }}
+  {{- if or (not $old_sec) (not $old_sec.data) }}
+  password: {{ randAlphaNum 20 | b64enc | b64enc }}
+  {{- else }}
+  password: {{ $old_sec.data.password }}
+  {{- end }}
+{{- end }}

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -119,17 +119,33 @@ redis:
     existingSecret: "redis-secret"
     existingSecretPasswordKey: "password"
   architecture: "replication"
+  rbac:
+    create: true
+  sentinel:
+    enabled: true
+    quorum: 2
+    service:
+      createMaster: true
+    startupProbe:
+      initialDelaySeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 5
+    readinessProbe:
+      initialDelaySeconds: 5
   fullnameOverride: "metoro-redis"
   pdb:
     create: true
     maxUnavailable: 1
-  master:
-    resourcesPreset: "micro"
-    persistence:
-      enabled: true
   replica:
-    replicaCount: 2
+    replicaCount: 3
     resourcesPreset: "micro"
+    automountServiceAccountToken: true
+    livenessProbe:
+      initialDelaySeconds: 5
+    readinessProbe:
+      initialDelaySeconds: 5
+    startupProbe:
+      initialDelaySeconds: 5
     persistence:
       enabled: true
 

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -118,12 +118,37 @@ redis:
     enabled: false
     existingSecret: "redis-secret"
     existingSecretPasswordKey: "password"
-  architecture: standalone
+  architecture: "replication"
   fullnameOverride: "metoro-redis"
+  pdb:
+    create: true
+    maxUnavailable: 1
   master:
-    resourcesPreset: "medium"
+    resourcesPreset: "micro"
     persistence:
       enabled: true
+    podDisruptionBudget:
+      enabled: true
+      maxUnavailable: 1
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfied: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: redis
+  replica:
+    replicaCount: 2
+    resourcesPreset: "micro"
+    persistence:
+      enabled: true
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfied: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: redis
 
 # Otel Instrumentation
 instrumentationWebhook:

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -118,6 +118,19 @@ redis:
     enabled: false
     existingSecret: "redis-secret"
     existingSecretPasswordKey: "password"
+  architecture: standalone
+  fullnameOverride: "metoro-redis"
+  master:
+    resourcesPreset: "medium"
+    persistence:
+      enabled: true
+
+redisCluster:
+  enabled: false
+  auth:
+    enabled: false
+    existingSecret: "redis-secret"
+    existingSecretPasswordKey: "password"
   architecture: "replication"
   rbac:
     create: true

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -127,28 +127,11 @@ redis:
     resourcesPreset: "micro"
     persistence:
       enabled: true
-    podDisruptionBudget:
-      enabled: true
-      maxUnavailable: 1
-    topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfied: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/name: redis
   replica:
     replicaCount: 2
     resourcesPreset: "micro"
     persistence:
       enabled: true
-    topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfied: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/name: redis
 
 # Otel Instrumentation
 instrumentationWebhook:


### PR DESCRIPTION
This PR adds an additional dependency: redisCluster.

redisCluster uses three redis pods, 1 is a master, the other two are replicas. Sentinel monitors for when the master is unreachable and promotes a replica when it goes down.

By default this is disabled, we will run it in our test clusters for some time then enable it by default.

If you would like to use the cluster regardless you can set `redis.enabled=false` and `redisCluster.enabled=true`