### PR TITLE
Upgrade exporter HPA to v2

### DIFF
--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the Metoro Exporter
 
 type: application
 
-version: 0.465.0
+version: 0.466.0
 appVersion: 0.919.0
 
 

--- a/charts/metoro-exporter/templates/exporter_horiztonal_pod_autoscaler.yaml
+++ b/charts/metoro-exporter/templates/exporter_horiztonal_pod_autoscaler.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.exporter.autoscaling.horizontalPodAutoscaler.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   namespace: {{ .Release.Namespace }}
@@ -11,5 +11,11 @@ spec:
     name: {{ .Values.exporter.metadata.name}}
   minReplicas: {{ .Values.exporter.autoscaling.horizontalPodAutoscaler.minReplicas}}
   maxReplicas: {{ .Values.exporter.autoscaling.horizontalPodAutoscaler.maxReplicas}}
-  targetCPUUtilizationPercentage: {{ .Values.exporter.autoscaling.horizontalPodAutoscaler.targetCPUUtilizationPercentage}}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.exporter.autoscaling.horizontalPodAutoscaler.targetCPUUtilizationPercentage}}
 {{- end -}}


### PR DESCRIPTION
Move to the non-deprecated v2 resource for hpa. This caused some reconciliation issues with argo installs as per https://github.com/argoproj/argo-cd/issues/12901