### PR TITLE
Reduce Redis startup time from ~30s to ~5s

### DIFF
--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -127,6 +127,12 @@ redis:
     pullPolicy: "IfNotPresent"
   master:
     resourcesPreset: "medium"
+    startupProbe:
+      initialDelaySeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 5
+    readinessProbe:
+      initialDelaySeconds: 5
     persistence:
       enabled: true
 


### PR DESCRIPTION
## Summary
- Configure startup, liveness, and readiness probes with `initialDelaySeconds: 5` for standalone Redis master
- Previously used Bitnami chart defaults (~20s initial delay), causing ~30s startup time

## Motivation
- New clusters come online faster
- Existing clusters recover more quickly when Redis pods move between nodes

## Test plan
- [ ] Deploy to a test cluster and verify Redis becomes ready in ~5-10 seconds
- [ ] Verify Redis functions correctly after the faster startup