### PR TITLE
Add graceful shutdown support to metoro-exporter

### DIFF
--- a/charts/metoro-exporter/templates/exporter_deployment.yaml
+++ b/charts/metoro-exporter/templates/exporter_deployment.yaml
@@ -27,6 +27,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.exporter.serviceAccount.name }}
+      {{- if .Values.exporter.gracefulShutdown.enabled }}
+      terminationGracePeriodSeconds: {{ .Values.exporter.gracefulShutdown.terminationGracePeriodSeconds }}
+      {{- end }}
       # We want to attempt to put the exporter on different nodes so that if a node goes down, we don't become unavailable
       affinity:
         podAntiAffinity:

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -64,6 +64,10 @@ exporter:
       minReplicas: 2
       maxReplicas: 10
       targetCPUUtilizationPercentage: 70
+  gracefulShutdown:
+    enabled: true
+    # Time to wait for inflight requests to complete after SIGTERM
+    terminationGracePeriodSeconds: 15
 # Node Agent
 nodeAgent:
   metadata:


### PR DESCRIPTION
## Summary
- Adds configurable graceful shutdown to the metoro-exporter Deployment
- Allows inflight requests to complete before pod termination

## Changes
- Added `gracefulShutdown` config to `values.yaml` with:
  - `terminationGracePeriodSeconds: 15` (configurable)
- Updated `exporter_deployment.yaml` with terminationGracePeriodSeconds

## How it works
1. Pod termination starts → SIGTERM sent to app
2. App drains inflight requests (up to 15s grace period)
3. Grace period expires → SIGKILL if needed