### PR TITLE
Add liveness and readiness probes to exporter deployment

### DIFF
--- a/charts/metoro-exporter/templates/exporter_deployment.yaml
+++ b/charts/metoro-exporter/templates/exporter_deployment.yaml
@@ -109,6 +109,21 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.exporter.resources | nindent 12 }}
+          # failureThreshold is 24 (120s) because the exporter takes time to populate caches on startup
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 24
+          readinessProbe:
+            httpGet:
+              path: /api/v1/readiness
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 24
           volumeMounts:
             - name: {{ .Values.exporter.configMap.name }}
               mountPath: /etc/exporter


### PR DESCRIPTION
## Summary
- Adds liveness probe using `/health` endpoint to detect unhealthy containers
- Adds readiness probe using `/api/v1/readiness` endpoint to control traffic routing
- Both probes configured with 5s initial delay, 5s polling interval, and 24 failure threshold (~125s tolerance for slow startups)

## Test plan
- [ ] Deploy to a test cluster and verify probes are working
- [ ] Check that pods restart when liveness probe fails
- [ ] Verify traffic stops routing to pods when readiness probe fails