### PR TITLE
Add Helm support for expanded Kubernetes resource watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ interesting values.
 | `redis.master.nodeSelector`         | map  | `{}`    | Node selector for the exporter redis instance                                                                         |
 | `redis.master.tolerations`          | list | `[]`    | Tolerations for the exporter redis instance                                                                           |
 | `redis.master.affinity`             | map  | `{}`    | Affinity for the exporter redis instance                                                                              |
-
+| `exporter.envVars.optional.k8sResources` | string | `""` | Optional comma-separated Kubernetes resource selectors passed to `METORO_K8S_RESOURCES`; leave empty to watch all supported resources |
 

--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the Metoro Exporter
 
 type: application
 
-version: 0.469.0
+version: 0.470.0
 appVersion: 0.919.0
 
 

--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -5,7 +5,7 @@ description: A helm chart for the Metoro Exporter
 type: application
 
 version: 0.470.0
-appVersion: 0.919.0
+appVersion: 0.2303.0
 
 
 dependencies:

--- a/charts/metoro-exporter/templates/exporter_deployment.yaml
+++ b/charts/metoro-exporter/templates/exporter_deployment.yaml
@@ -104,6 +104,10 @@ spec:
               value: release
             - name: SHOULD_DROP_METORO_DATA
               value: {{ .Values.exporter.envVars.mandatory.shouldDropMetoroData | quote }}
+            {{- if .Values.exporter.envVars.optional.k8sResources }}
+            - name: METORO_K8S_RESOURCES
+              value: {{ .Values.exporter.envVars.optional.k8sResources | quote }}
+            {{- end }}
             {{- with .Values.exporter.envVars.userDefined }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}

--- a/charts/metoro-exporter/templates/exporter_service_account.yaml
+++ b/charts/metoro-exporter/templates/exporter_service_account.yaml
@@ -18,7 +18,7 @@ rules:
     verbs: ["get", "list", "create", "update", "delete"]
   # The rest of these are just so we can export the state of the cluster
   - apiGroups: [""]
-    resources: ["pods", "nodes", "services", "endpoints", "namespaces", "configmaps", "events"]
+    resources: ["pods", "nodes", "services", "endpoints", "namespaces", "configmaps", "events", "serviceaccounts", "persistentvolumeclaims", "persistentvolumes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
@@ -30,7 +30,7 @@ rules:
     resources: ["horizontalpodautoscalers"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "networking.k8s.io" ]
-    resources: [ "ingresses" ]
+    resources: [ "ingresses", "networkpolicies" ]
     verbs: [ "get", "list", "watch" ]
 
 ---

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -17,6 +17,10 @@ exporter:
       otlpUrl: "https://us-east.metoro.io/ingest/api/v1/otel"
       apiServerUrl: "https://us-east.metoro.io/api/v1/exporter"
       shouldDropMetoroData: "true"
+    optional:
+      # Comma-separated selectors for Kubernetes resources to watch (for example: "pod,service,deployment,ingress").
+      # Leave empty to watch all exporter-supported resources.
+      k8sResources: ""
     userDefined: {}
   image:
     tag: "v2-stable"


### PR DESCRIPTION
## High level goal
Update the `metoro-exporter` Helm chart so it fully supports the expanded Kubernetes resource coverage recently added in the exporter, including a first-class value for resource selector configuration.

## Desired behavior
1. Clusters installed via Helm grant the exporter RBAC permissions for all newly watched resources.
2. Operators can configure `METORO_K8S_RESOURCES` directly via values without relying on generic user-defined env overrides.
3. Chart metadata reflects this chart change.

## Specific implementation details
- Added exporter RBAC permissions for:
  - Core resources: `serviceaccounts`, `persistentvolumeclaims`, `persistentvolumes`
  - Networking resources: `networkpolicies` (alongside existing `ingresses`)
- Added `exporter.envVars.optional.k8sResources` to `values.yaml` and mapped it to `METORO_K8S_RESOURCES` in the exporter deployment when non-empty.
- Documented the new value in the repo `README.md`.
- Bumped chart version from `0.469.0` to `0.470.0`.

## Validation
- `helm lint charts/metoro-exporter`
- `helm template test charts/metoro-exporter`
- `helm template test charts/metoro-exporter -f /tmp/metoro_vals.yaml` (with `exporter.envVars.optional.k8sResources: "pod,service,ingress"`) to verify conditional env rendering.
