### PR TITLE
Add CloudWatch metrics plugin to metoro-exporter chart

### DIFF
--- a/charts/metoro-exporter/files/plugins/cloudwatch/alb.yaml
+++ b/charts/metoro-exporter/files/plugins/cloudwatch/alb.yaml
@@ -1,0 +1,23 @@
+# Curated CloudWatch metric set for AWS Application Load Balancer.
+type: AWS/ApplicationELB
+metrics:
+  - name: RequestCount
+    statistics: [Sum]
+  - name: HTTPCode_Target_2XX_Count
+    statistics: [Sum]
+  - name: HTTPCode_Target_4XX_Count
+    statistics: [Sum]
+  - name: HTTPCode_Target_5XX_Count
+    statistics: [Sum]
+  - name: HTTPCode_ELB_5XX_Count
+    statistics: [Sum]
+  - name: TargetResponseTime
+    statistics: [Average, p99]
+  - name: HealthyHostCount
+    statistics: [Minimum]
+  - name: UnHealthyHostCount
+    statistics: [Maximum]
+  - name: ActiveConnectionCount
+    statistics: [Sum]
+  - name: TargetConnectionErrorCount
+    statistics: [Sum]

--- a/charts/metoro-exporter/files/plugins/cloudwatch/dynamodb.yaml
+++ b/charts/metoro-exporter/files/plugins/cloudwatch/dynamodb.yaml
@@ -1,0 +1,19 @@
+# Curated CloudWatch metric set for Amazon DynamoDB.
+type: AWS/DynamoDB
+metrics:
+  - name: ConsumedReadCapacityUnits
+    statistics: [Sum]
+  - name: ConsumedWriteCapacityUnits
+    statistics: [Sum]
+  - name: ThrottledRequests
+    statistics: [Sum]
+  - name: ReadThrottleEvents
+    statistics: [Sum]
+  - name: WriteThrottleEvents
+    statistics: [Sum]
+  - name: SuccessfulRequestLatency
+    statistics: [Average, Maximum]
+  - name: SystemErrors
+    statistics: [Sum]
+  - name: UserErrors
+    statistics: [Sum]

--- a/charts/metoro-exporter/files/plugins/cloudwatch/elasticache.yaml
+++ b/charts/metoro-exporter/files/plugins/cloudwatch/elasticache.yaml
@@ -1,0 +1,23 @@
+# Curated CloudWatch metric set for Amazon ElastiCache.
+type: AWS/ElastiCache
+metrics:
+  - name: CPUUtilization
+    statistics: [Average, Maximum]
+  - name: EngineCPUUtilization
+    statistics: [Average, Maximum]
+  - name: DatabaseMemoryUsagePercentage
+    statistics: [Average, Maximum]
+  - name: CurrConnections
+    statistics: [Average, Maximum]
+  - name: Evictions
+    statistics: [Sum]
+  - name: CacheHits
+    statistics: [Sum]
+  - name: CacheMisses
+    statistics: [Sum]
+  - name: NetworkBytesIn
+    statistics: [Sum]
+  - name: NetworkBytesOut
+    statistics: [Sum]
+  - name: ReplicationLag
+    statistics: [Average, Maximum]

--- a/charts/metoro-exporter/files/plugins/cloudwatch/lambda.yaml
+++ b/charts/metoro-exporter/files/plugins/cloudwatch/lambda.yaml
@@ -1,0 +1,17 @@
+# Curated CloudWatch metric set for AWS Lambda.
+type: AWS/Lambda
+metrics:
+  - name: Invocations
+    statistics: [Sum]
+  - name: Errors
+    statistics: [Sum]
+  - name: Throttles
+    statistics: [Sum]
+  - name: Duration
+    statistics: [Average, Maximum]
+  - name: ConcurrentExecutions
+    statistics: [Maximum]
+  - name: AsyncEventsReceived
+    statistics: [Sum]
+  - name: AsyncEventAge
+    statistics: [Average, Maximum]

--- a/charts/metoro-exporter/files/plugins/cloudwatch/rds.yaml
+++ b/charts/metoro-exporter/files/plugins/cloudwatch/rds.yaml
@@ -1,0 +1,27 @@
+# Curated CloudWatch metric set for Amazon RDS.
+type: AWS/RDS
+metrics:
+  - name: CPUUtilization
+    statistics: [Average, Maximum]
+  - name: DatabaseConnections
+    statistics: [Average, Maximum]
+  - name: FreeableMemory
+    statistics: [Average, Minimum]
+  - name: FreeStorageSpace
+    statistics: [Average, Minimum]
+  - name: ReadLatency
+    statistics: [Average, Maximum]
+  - name: WriteLatency
+    statistics: [Average, Maximum]
+  - name: ReadIOPS
+    statistics: [Average]
+  - name: WriteIOPS
+    statistics: [Average]
+  - name: DiskQueueDepth
+    statistics: [Average]
+  - name: ReplicaLag
+    statistics: [Average, Maximum]
+  - name: BurstBalance
+    statistics: [Minimum]
+  - name: SwapUsage
+    statistics: [Average]

--- a/charts/metoro-exporter/files/plugins/cloudwatch/sqs.yaml
+++ b/charts/metoro-exporter/files/plugins/cloudwatch/sqs.yaml
@@ -1,0 +1,21 @@
+# Curated CloudWatch metric set for Amazon SQS.
+type: AWS/SQS
+metrics:
+  - name: ApproximateNumberOfMessagesVisible
+    statistics: [Average, Maximum]
+  - name: ApproximateNumberOfMessagesNotVisible
+    statistics: [Average]
+  - name: ApproximateNumberOfMessagesDelayed
+    statistics: [Average]
+  - name: ApproximateAgeOfOldestMessage
+    statistics: [Average, Maximum]
+  - name: NumberOfMessagesSent
+    statistics: [Sum]
+  - name: NumberOfMessagesReceived
+    statistics: [Sum]
+  - name: NumberOfMessagesDeleted
+    statistics: [Sum]
+  - name: NumberOfEmptyReceives
+    statistics: [Sum]
+  - name: SentMessageSize
+    statistics: [Average, Maximum]

--- a/charts/metoro-exporter/templates/_helpers.tpl
+++ b/charts/metoro-exporter/templates/_helpers.tpl
@@ -136,6 +136,88 @@ app.kubernetes.io/component: opentelemetry-targetallocator
 {{- end }}
 
 {{/*
+Common non-selector labels for plugin resources.
+*/}}
+{{- define "metoro.plugins.commonLabels" -}}
+helm.sh/chart: {{ include "metoro.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Create the name of the CloudWatch plugin.
+*/}}
+{{- define "metoro.plugins.cloudwatch.name" -}}
+{{- printf "%s-plugin-cloudwatch" (include "metoro.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create the name of the CloudWatch plugin scraper (YACE) config map.
+*/}}
+{{- define "metoro.plugins.cloudwatch.configMapName" -}}
+{{- printf "%s-config" (include "metoro.plugins.cloudwatch.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create the name of the CloudWatch plugin collector sidecar config map.
+*/}}
+{{- define "metoro.plugins.cloudwatch.sidecarConfigMapName" -}}
+{{- printf "%s-sidecar-config" (include "metoro.plugins.cloudwatch.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create selector labels used by the CloudWatch plugin.
+*/}}
+{{- define "metoro.plugins.cloudwatch.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metoro.plugins.cloudwatch.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: plugin-cloudwatch
+{{- end }}
+
+{{/*
+Render the YACE configuration for the CloudWatch plugin from the curated metric
+sets in files/plugins/cloudwatch and the user's plugins.cloudwatch.services values.
+*/}}
+{{- define "metoro.plugins.cloudwatch.yaceConfig" -}}
+{{- $cw := .Values.plugins.cloudwatch -}}
+{{- if $cw.customConfig -}}
+{{- $cw.customConfig -}}
+{{- else -}}
+{{- $jobs := list -}}
+{{- range $svc := $cw.services -}}
+{{- $path := printf "files/plugins/cloudwatch/%s.yaml" $svc.name -}}
+{{- $curatedRaw := $.Files.Get $path -}}
+{{- if not $curatedRaw -}}
+{{- fail (printf "plugins.cloudwatch: unsupported service %q. Supported services: rds, sqs, lambda, alb, elasticache, dynamodb. Use plugins.cloudwatch.customConfig for anything else." $svc.name) -}}
+{{- end -}}
+{{- $curated := fromYaml $curatedRaw -}}
+{{- $period := int ($svc.period | default $cw.scrape.period) -}}
+{{- $job := dict
+      "type" $curated.type
+      "regions" ($svc.regions | default $cw.aws.regions)
+      "period" $period
+      "length" $period
+      "delay" (int $cw.scrape.delay)
+      "nilToZero" $cw.scrape.nilToZero
+      "metrics" ($svc.metrics | default $curated.metrics)
+-}}
+{{- with $svc.searchTags -}}
+{{- $_ := set $job "searchTags" . -}}
+{{- end -}}
+{{- $jobs = append $jobs $job -}}
+{{- end -}}
+{{- $config := dict
+      "apiVersion" "v1alpha1"
+      "sts-region" $cw.aws.stsRegion
+      "discovery" (dict "jobs" $jobs)
+-}}
+{{- toYaml $config -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Render a Kubernetes LabelSelector for the Target Allocator config. The pinned
 Target Allocator version unmarshals LabelSelector fields using lower-case YAML
 field names.

--- a/charts/metoro-exporter/templates/plugin_cloudwatch.yaml
+++ b/charts/metoro-exporter/templates/plugin_cloudwatch.yaml
@@ -8,12 +8,13 @@
 {{- $sidecarConfigMapName := include "metoro.plugins.cloudwatch.sidecarConfigMapName" . -}}
 {{- $yaceConfig := include "metoro.plugins.cloudwatch.yaceConfig" . -}}
 {{- $exporterMetricsEndpoint := printf "http://%s.%s.svc.cluster.local:%d/api/v1/custom/otel/metrics" .Values.exporter.services.metoroExporter.name .Release.Namespace (.Values.exporter.services.metoroExporter.port | int) -}}
-{{- /* Poll and scrape at the smallest period across services so that a per-service
-period override actually increases export resolution rather than dropping datapoints. */ -}}
-{{- $scrapeInterval := int $cw.scrape.period -}}
+{{- /* YACE polls CloudWatch at the smallest period across services so that a
+per-service period override actually increases resolution rather than dropping
+datapoints. The sidecar scrapes YACE's cached values on its own faster cadence. */ -}}
+{{- $yacePollInterval := int $cw.scrape.period -}}
 {{- range $svc := $cw.services -}}
 {{- if $svc.period -}}
-{{- $scrapeInterval = min $scrapeInterval (int $svc.period) -}}
+{{- $yacePollInterval = min $yacePollInterval (int $svc.period) -}}
 {{- end -}}
 {{- end -}}
 apiVersion: v1
@@ -43,7 +44,7 @@ data:
         config:
           scrape_configs:
             - job_name: metoro-plugin-cloudwatch
-              scrape_interval: {{ $scrapeInterval }}s
+              scrape_interval: {{ $cw.scrape.interval }}s
               static_configs:
                 - targets: ["127.0.0.1:5000"]
     processors:
@@ -105,7 +106,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ printf "%s%s%d" $yaceConfig $exporterMetricsEndpoint $scrapeInterval | sha256sum }}
+        checksum/config: {{ printf "%s%s%d%d" $yaceConfig $exporterMetricsEndpoint $yacePollInterval (int $cw.scrape.interval) | sha256sum }}
       labels:
         {{- include "metoro.plugins.commonLabels" . | nindent 8 }}
         {{- include "metoro.plugins.cloudwatch.selectorLabels" . | nindent 8 }}
@@ -145,7 +146,7 @@ spec:
           args:
             - -config.file=/config/config.yml
             - -listen-address=:5000
-            - -scraping-interval={{ $scrapeInterval }}
+            - -scraping-interval={{ $yacePollInterval }}
           {{- with $cw.aws.auth.existingSecret }}
           envFrom:
             - secretRef:

--- a/charts/metoro-exporter/templates/plugin_cloudwatch.yaml
+++ b/charts/metoro-exporter/templates/plugin_cloudwatch.yaml
@@ -1,0 +1,196 @@
+{{- if .Values.plugins.cloudwatch.enabled -}}
+{{- $cw := .Values.plugins.cloudwatch -}}
+{{- if and (not $cw.services) (not $cw.customConfig) -}}
+{{- fail "plugins.cloudwatch: at least one entry in plugins.cloudwatch.services (or a customConfig) is required when the plugin is enabled" -}}
+{{- end -}}
+{{- $name := include "metoro.plugins.cloudwatch.name" . -}}
+{{- $configMapName := include "metoro.plugins.cloudwatch.configMapName" . -}}
+{{- $sidecarConfigMapName := include "metoro.plugins.cloudwatch.sidecarConfigMapName" . -}}
+{{- $yaceConfig := include "metoro.plugins.cloudwatch.yaceConfig" . -}}
+{{- $exporterMetricsEndpoint := printf "http://%s.%s.svc.cluster.local:%d/api/v1/custom/otel/metrics" .Values.exporter.services.metoroExporter.name .Release.Namespace (.Values.exporter.services.metoroExporter.port | int) -}}
+{{- /* Poll and scrape at the smallest period across services so that a per-service
+period override actually increases export resolution rather than dropping datapoints. */ -}}
+{{- $scrapeInterval := int $cw.scrape.period -}}
+{{- range $svc := $cw.services -}}
+{{- if $svc.period -}}
+{{- $scrapeInterval = min $scrapeInterval (int $svc.period) -}}
+{{- end -}}
+{{- end -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $configMapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metoro.plugins.commonLabels" . | nindent 4 }}
+    {{- include "metoro.plugins.cloudwatch.selectorLabels" . | nindent 4 }}
+data:
+  config.yml: |-
+    {{- $yaceConfig | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $sidecarConfigMapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metoro.plugins.commonLabels" . | nindent 4 }}
+    {{- include "metoro.plugins.cloudwatch.selectorLabels" . | nindent 4 }}
+data:
+  collector.yaml: |-
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: metoro-plugin-cloudwatch
+              scrape_interval: {{ $scrapeInterval }}s
+              static_configs:
+                - targets: ["127.0.0.1:5000"]
+    processors:
+      resource:
+        attributes:
+          - key: metoro.plugin
+            value: cloudwatch
+            action: upsert
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+
+    exporters:
+      otlphttp/metoro:
+        metrics_endpoint: {{ $exporterMetricsEndpoint | quote }}
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: [resource, batch]
+          exporters: [otlphttp/metoro]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $cw.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metoro.plugins.commonLabels" . | nindent 4 }}
+    {{- include "metoro.plugins.cloudwatch.selectorLabels" . | nindent 4 }}
+  {{- if or $cw.aws.auth.roleArn $cw.serviceAccount.annotations }}
+  annotations:
+    {{- with $cw.aws.auth.roleArn }}
+    eks.amazonaws.com/role-arn: {{ . | quote }}
+    {{- end }}
+    {{- with $cw.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metoro.plugins.commonLabels" . | nindent 4 }}
+    {{- include "metoro.plugins.cloudwatch.selectorLabels" . | nindent 4 }}
+spec:
+  # YACE polls CloudWatch on its own schedule, so a second replica would double the
+  # customer's CloudWatch API bill and duplicate every datapoint. Run exactly one.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "metoro.plugins.cloudwatch.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ printf "%s%s%d" $yaceConfig $exporterMetricsEndpoint $scrapeInterval | sha256sum }}
+      labels:
+        {{- include "metoro.plugins.commonLabels" . | nindent 8 }}
+        {{- include "metoro.plugins.cloudwatch.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ $cw.serviceAccount.name }}
+      {{- with $cw.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $cw.scheduling.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $cw.scheduling.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $cw.scheduling.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      tolerations:
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: {{ $cw.scheduling.nodeFailureEvictionSeconds }}
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: {{ $cw.scheduling.nodeFailureEvictionSeconds }}
+        {{- with $cw.scheduling.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: yace
+          image: "{{ $cw.image.repository }}:{{ $cw.image.tag }}"
+          imagePullPolicy: {{ $cw.image.pullPolicy }}
+          args:
+            - -config.file=/config/config.yml
+            - -listen-address=:5000
+            - -scraping-interval={{ $scrapeInterval }}
+          {{- with $cw.aws.auth.existingSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ . }}
+          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 5000
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+          volumeMounts:
+            - name: yace-config
+              mountPath: /config
+          {{- with $cw.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        - name: otel-sidecar
+          image: "{{ $cw.sidecar.image.repository }}:{{ $cw.sidecar.image.tag }}"
+          imagePullPolicy: {{ $cw.sidecar.image.pullPolicy }}
+          args:
+            - --config=/conf/collector.yaml
+          volumeMounts:
+            - name: sidecar-config
+              mountPath: /conf
+          {{- with $cw.sidecar.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: yace-config
+          configMap:
+            name: {{ $configMapName }}
+            items:
+              - key: config.yml
+                path: config.yml
+        - name: sidecar-config
+          configMap:
+            name: {{ $sidecarConfigMapName }}
+            items:
+              - key: collector.yaml
+                path: collector.yaml
+{{- end -}}

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -181,6 +181,95 @@ redisCluster:
     persistence:
       enabled: true
 
+# Plugins scrape metrics from sources outside the cluster and ship them to Metoro
+# through the in-cluster exporter. Each plugin runs as its own single-replica
+# deployment containing the scraper plus a small OpenTelemetry collector sidecar.
+plugins:
+  # Scrapes AWS CloudWatch metrics using YACE (yet-another-cloudwatch-exporter).
+  # Resources are discovered via the AWS tagging API, so the IAM role/user needs:
+  #   cloudwatch:ListMetrics, cloudwatch:GetMetricData, tag:GetResources
+  # Note: CloudWatch charges ~$0.01 per 1,000 metrics requested via GetMetricData.
+  # The defaults below (5 minute period, explicit service opt-in) are chosen to keep
+  # that cost low. Use searchTags to narrow discovery to the resources you care about.
+  cloudwatch:
+    enabled: false
+    aws:
+      # Region used for STS authentication.
+      stsRegion: "us-east-1"
+      # Regions to discover and scrape resources in. Can be overridden per service.
+      regions: ["us-east-1"]
+      auth:
+        # IAM role ARN for IRSA on EKS. Rendered as the eks.amazonaws.com/role-arn
+        # annotation on the plugin's service account. Leave empty if credentials come
+        # from elsewhere (EKS Pod Identity, node instance profile, or existingSecret).
+        roleArn: ""
+        # Name of an existing secret containing AWS_ACCESS_KEY_ID and
+        # AWS_SECRET_ACCESS_KEY keys, for clusters without IRSA.
+        existingSecret: ""
+    scrape:
+      # CloudWatch granularity to request, in seconds. Most AWS namespaces emit at
+      # 1 minute resolution but 5 minutes keeps GetMetricData costs low.
+      period: 300
+      # How far back to offset requests, in seconds. CloudWatch datapoints take a few
+      # minutes to settle; querying too close to now returns partial data.
+      delay: 300
+      # Export 0 instead of NaN when a resource reports no data for an interval.
+      nilToZero: true
+    # Services to scrape using Metoro's curated metric sets.
+    # Supported names: rds, sqs, lambda, alb, elasticache, dynamodb.
+    services: []
+    #  - name: rds
+    #    regions: ["us-east-1"]            # optional, defaults to aws.regions
+    #    searchTags:                       # optional, narrows discovery by resource tags
+    #      - key: "environment"
+    #        value: "production"           # value is a regex
+    #    period: 60                        # optional, overrides scrape.period. The plugin polls
+    #                                      # CloudWatch at the smallest period across all services,
+    #                                      # so a low value here raises API cost for the whole plugin.
+    #    metrics:                          # optional, replaces the curated metric set
+    #      - name: "CPUUtilization"
+    #        statistics: ["Average"]
+    # Escape hatch: a verbatim YACE configuration (https://github.com/prometheus-community/yet-another-cloudwatch-exporter).
+    # When set, `aws.stsRegion`, `scrape` and `services` are ignored.
+    customConfig: ""
+    serviceAccount:
+      name: "metoro-plugin-cloudwatch"
+      # Extra annotations for the service account, merged with the IRSA annotation.
+      annotations: {}
+    image:
+      repository: quay.io/prometheuscommunity/yet-another-cloudwatch-exporter
+      tag: "v0.65.0"
+      pullPolicy: "IfNotPresent"
+      imagePullSecrets: []
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+    sidecar:
+      image:
+        repository: quay.io/metoro/opentelemetry-collector
+        tag: "stable"
+        pullPolicy: "Always"
+      resources:
+        limits:
+          cpu: "250m"
+          memory: "256Mi"
+        requests:
+          cpu: "50m"
+          memory: "64Mi"
+    scheduling:
+      nodeSelector: {}
+      affinity: {}
+      tolerations: []
+      priorityClassName: ""
+      # How long the pod tolerates a NotReady/unreachable node before being evicted
+      # and rescheduled. The plugin runs as a single replica, so this bounds the
+      # metric gap after a node failure. The Kubernetes default is 300 seconds.
+      nodeFailureEvictionSeconds: 60
+
 serviceMonitorScraping:
   enabled: false
 

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -207,6 +207,11 @@ plugins:
         # AWS_SECRET_ACCESS_KEY keys, for clusters without IRSA.
         existingSecret: ""
     scrape:
+      # How often the otel sidecar scrapes YACE and exports samples, in seconds.
+      # YACE only refreshes from CloudWatch every `period` seconds, so values repeat
+      # between refreshes, but a steady 30s cadence keeps plugin metrics behaving
+      # like every other metric in Metoro. Does not affect CloudWatch API cost.
+      interval: 30
       # CloudWatch granularity to request, in seconds. Most AWS namespaces emit at
       # 1 minute resolution but 5 minutes keeps GetMetricData costs low.
       period: 300

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -192,6 +192,9 @@ plugins:
   # The defaults below (5 minute period, explicit service opt-in) are chosen to keep
   # that cost low. Use searchTags to narrow discovery to the resources you care about.
   cloudwatch:
+    # ALPHA: this plugin is under active development and is not yet generally
+    # available. Configuration may change between chart versions without notice.
+    # Do not enable unless the Metoro team has asked you to.
     enabled: false
     aws:
       # Region used for STS authentication.


### PR DESCRIPTION
## Summary

Adds a `plugins` section to the metoro-exporter chart — a way to scrape metrics from sources outside the cluster and ship them to Metoro through the existing exporter ingest path. The first plugin scrapes AWS CloudWatch via [YACE](https://github.com/prometheus-community/yet-another-cloudwatch-exporter) (v0.65.0).

Each plugin runs as a self-contained single-replica deployment: the scraper plus a small otel-collector sidecar that scrapes it over localhost, stamps a `metoro.plugin` resource attribute for attribution, and exports to the in-cluster exporter's custom OTLP metrics endpoint. Nothing renders unless `plugins.cloudwatch.enabled` is set. The plugin is marked **alpha** in values.yaml — config may change between chart versions, and customers are told not to enable it unless asked to.

## Configuration

```yaml
plugins:
  cloudwatch:
    enabled: true
    aws:
      stsRegion: "eu-west-1"
      regions: ["eu-west-1"]
      auth:
        roleArn: "arn:aws:iam::123456789012:role/metoro-cloudwatch"  # IRSA; or existingSecret for access keys
    services:
      - name: rds
        searchTags:
          - key: "environment"
            value: "production"
```

- **Curated metric sets** for `rds`, `sqs`, `lambda`, `alb`, `elasticache`, `dynamodb` live under `files/plugins/cloudwatch/` — users opt into services by name, we own which metrics/statistics are scraped. Adding a service later is one new file.
- **Cost guardrails**: 5-minute period/delay defaults, explicit service opt-in, tag-based discovery filters. The required IAM policy (`cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, `tag:GetResources`) and the GetMetricData pricing caveat are documented in values.yaml.
- **`customConfig` escape hatch**: a verbatim YACE config for anything the curated sets don't cover.
- **Single replica by design**: YACE polls CloudWatch on its own schedule, so a second replica doubles the customer's API bill and duplicates every datapoint. Node-failure eviction is tightened to 60s (configurable) to bound the gap instead.
- The otel sidecar scrapes YACE at a fixed 30s cadence (`scrape.interval`) so plugin metrics have the same sample frequency as the rest of Metoro's metrics; YACE's own CloudWatch polling runs at the smallest period across configured services, so a per-service `period` override raises resolution instead of silently dropping datapoints.

## Testing

- `helm lint` passes; default values render zero plugin resources
- Rendered with curated services (multi-region, searchTags, per-service period override), `customConfig`, and secret-based auth; YACE and collector configs validated with yq
- Unsupported service names and enabled-with-empty-config fail rendering with clear messages

## Follow-ups (out of scope here)

- Mirror the YACE image to quay.io/metoro and switch the default repository
- Confirm the exporter's custom-metrics pass-through doesn't filter unfamiliar metric names; consider a dedicated usage-metering type for plugin metrics
- Deploy to a dev cluster against a real AWS account for end-to-end verification
- Docs page in the main repo


