### PR TITLE
[codex] Add Prometheus Operator RBAC to exporter

### DIFF
--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the Metoro Exporter
 
 type: application
 
-version: 0.472.0
+version: 0.473.0
 appVersion: 0.2303.0
 
 

--- a/charts/metoro-exporter/templates/exporter_service_account.yaml
+++ b/charts/metoro-exporter/templates/exporter_service_account.yaml
@@ -32,6 +32,9 @@ rules:
   - apiGroups: [ "networking.k8s.io" ]
     resources: [ "ingresses", "networkpolicies" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "monitoring.coreos.com" ]
+    resources: [ "alertmanagerconfigs", "alertmanagers", "podmonitors", "probes", "prometheusagents", "prometheuses", "prometheusrules", "scrapeconfigs", "servicemonitors", "thanosrulers" ]
+    verbs: [ "get", "list", "watch" ]
 
 ---
 


### PR DESCRIPTION
## Summary

Adds read-only exporter RBAC for Prometheus Operator custom resources in the `monitoring.coreos.com` API group, including ServiceMonitor, PodMonitor, PrometheusRule, Probe, ScrapeConfig, Prometheus, PrometheusAgent, Alertmanager, AlertmanagerConfig, and ThanosRuler.

Bumps the `metoro-exporter` chart version from `0.472.0` to `0.473.0`.

## Why

The exporter recently gained support for exporting Prometheus rule-style resources, but the Helm chart did not grant permissions for those custom resources. Without these permissions, clusters with those CRDs installed can deny exporter list/watch calls.

## Impact

Clusters without these CRDs can still install the RBAC rule because Kubernetes accepts ClusterRole rules for resources that are not currently served. The exporter still needs to handle missing CRDs as optional at runtime when it attempts discovery or list/watch calls.

## Validation

- `helm dependency build charts/metoro-exporter --skip-refresh`
- `helm lint charts/metoro-exporter`
- `helm template metoro charts/metoro-exporter --namespace metoro-system`