### PR TITLE
Enable ServiceMonitor scraping by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ interesting values.
 
 #### ServiceMonitor and PodMonitor scraping
 
-The exporter chart can optionally deploy a pinned OpenTelemetry Collector and
-Target Allocator directly. The Target Allocator discovers Prometheus Operator
+The exporter chart deploys a pinned OpenTelemetry Collector and Target
+Allocator by default. The Target Allocator discovers Prometheus Operator
 `ServiceMonitor` and `PodMonitor` resources, the collector scrapes those
 targets, and metrics are forwarded to the in-cluster `metoro-exporter` service
 at `/api/v1/custom/otel/metrics`.
 
-Enable scraping with:
+Disable scraping with:
 
 ```yaml
 serviceMonitorScraping:
-  enabled: true
+  enabled: false
 ```
 
 This path does not install the OpenTelemetry Operator, OpenTelemetry CRDs, or
@@ -52,7 +52,6 @@ objects:
 
 ```yaml
 serviceMonitorScraping:
-  enabled: true
   collector:
     replicas: 2
   targetAllocator:

--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the Metoro Exporter
 
 type: application
 
-version: 0.473.0
+version: 0.473.1
 appVersion: 0.2303.0
 
 

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -182,7 +182,7 @@ redisCluster:
       enabled: true
 
 serviceMonitorScraping:
-  enabled: false
+  enabled: true
 
   collector:
     mode: statefulset


### PR DESCRIPTION
## Summary
- Enable ServiceMonitor and PodMonitor scraping by default in the exporter chart
- Document the opt-out value for clusters without Prometheus Operator CRDs
- Bump the chart version to 0.473.1

## Testing
- `helm lint charts/metoro-exporter --set redis.enabled=false --set redisCluster.enabled=false`
- Rendered a temporary dependency-built chart copy with defaults and confirmed the scraper stack is included
- Rendered with `--set serviceMonitorScraping.enabled=false` and confirmed scraper resources are omitted
