### PR TITLE
Add Metoro RBAC rule CRDs to exporter chart

### DIFF
--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the Metoro Exporter
 
 type: application
 
-version: 0.473.1
+version: 0.473.2
 appVersion: 0.2303.0
 
 

--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the Metoro Exporter
 
 type: application
 
-version: 0.473.2
+version: 0.473.3
 appVersion: 0.2303.0
 
 

--- a/charts/metoro-exporter/crds/rbac.metoro.io_metoroclusterresourcerules.yaml
+++ b/charts/metoro-exporter/crds/rbac.metoro.io_metoroclusterresourcerules.yaml
@@ -1,0 +1,108 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: metoroclusterresourcerules.rbac.metoro.io
+spec:
+  group: rbac.metoro.io
+  names:
+    kind: MetoroClusterResourceRule
+    listKind: MetoroClusterResourceRuleList
+    plural: metoroclusterresourcerules
+    singular: metoroclusterresourcerule
+    shortNames:
+      - mcresrule
+      - mcresrules
+    categories:
+      - metoro
+      - metoro-rbac
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Groups
+          type: string
+          jsonPath: .spec.groups
+        - name: Resources
+          type: string
+          jsonPath: .spec.rules[*].resources
+        - name: Verbs
+          type: string
+          jsonPath: .spec.rules[*].verbs
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: MetoroClusterResourceRule grants Metoro groups access to Metoro resources from the cluster where the rule is created.
+          required:
+            - spec
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - groups
+                - rules
+              properties:
+                groups:
+                  type: array
+                  description: Metoro groups this rule grants resource permissions to.
+                  minItems: 1
+                  maxItems: 256
+                  x-kubernetes-list-type: set
+                  items:
+                    type: string
+                    minLength: 1
+                    maxLength: 256
+                rules:
+                  type: array
+                  description: Allow-grants whose effective access is the union of all entries.
+                  minItems: 1
+                  maxItems: 256
+                  items:
+                    type: object
+                    required:
+                      - resources
+                      - verbs
+                    properties:
+                      resources:
+                        type: array
+                        description: Metoro resource types this grant covers.
+                        minItems: 1
+                        maxItems: 7
+                        x-kubernetes-list-type: set
+                        items:
+                          type: string
+                          enum:
+                            - dashboards
+                            - alerts
+                            - webhooks
+                            - ingestionFilters
+                            - redactionRules
+                            - aiWorkflowSettings
+                            - "*"
+                      verbs:
+                        type: array
+                        description: Actions this grant allows.
+                        minItems: 1
+                        maxItems: 4
+                        x-kubernetes-list-type: set
+                        items:
+                          type: string
+                          enum:
+                            - create
+                            - read
+                            - update
+                            - delete
+                      path:
+                        type: string
+                        description: Optional relative subpath that narrows the inherited cluster resource scope.
+                        maxLength: 1024

--- a/charts/metoro-exporter/crds/rbac.metoro.io_metoroclusterresourcerules.yaml
+++ b/charts/metoro-exporter/crds/rbac.metoro.io_metoroclusterresourcerules.yaml
@@ -77,24 +77,14 @@ spec:
                         type: array
                         description: Metoro resource types this grant covers.
                         minItems: 1
-                        maxItems: 13
+                        maxItems: 3
                         x-kubernetes-list-type: set
                         items:
                           type: string
                           enum:
-                            - billing
-                            - dashboards
                             - alerts
-                            - environments
-                            - logFilters
-                            - traceRedacts
-                            - integrations
-                            - workflows
-                            - accessManagement
-                            - investigations
-                            - apiKeys
-                            - memories
-                            - "*"
+                            - dashboards
+                            - webhooks
                       verbs:
                         type: array
                         description: Actions this grant allows.

--- a/charts/metoro-exporter/crds/rbac.metoro.io_metoroclusterresourcerules.yaml
+++ b/charts/metoro-exporter/crds/rbac.metoro.io_metoroclusterresourcerules.yaml
@@ -77,17 +77,23 @@ spec:
                         type: array
                         description: Metoro resource types this grant covers.
                         minItems: 1
-                        maxItems: 7
+                        maxItems: 13
                         x-kubernetes-list-type: set
                         items:
                           type: string
                           enum:
+                            - billing
                             - dashboards
                             - alerts
-                            - webhooks
-                            - ingestionFilters
-                            - redactionRules
-                            - aiWorkflowSettings
+                            - environments
+                            - logFilters
+                            - traceRedacts
+                            - integrations
+                            - workflows
+                            - accessManagement
+                            - investigations
+                            - apiKeys
+                            - memories
                             - "*"
                       verbs:
                         type: array

--- a/charts/metoro-exporter/crds/rbac.metoro.io_metoroclustertelemetryrules.yaml
+++ b/charts/metoro-exporter/crds/rbac.metoro.io_metoroclustertelemetryrules.yaml
@@ -86,10 +86,13 @@ spec:
                       match:
                         type: object
                         description: Optional telemetry attribute selector that narrows the inherited cluster scope.
+                        required:
+                          - matchExpressions
                         properties:
                           matchExpressions:
                             type: array
                             description: Attribute match expressions. Expressions are ANDed within a rule.
+                            minItems: 1
                             maxItems: 64
                             items:
                               type: object

--- a/charts/metoro-exporter/crds/rbac.metoro.io_metoroclustertelemetryrules.yaml
+++ b/charts/metoro-exporter/crds/rbac.metoro.io_metoroclustertelemetryrules.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: metoroclustertelemetryrules.rbac.metoro.io
+spec:
+  group: rbac.metoro.io
+  names:
+    kind: MetoroClusterTelemetryRule
+    listKind: MetoroClusterTelemetryRuleList
+    plural: metoroclustertelemetryrules
+    singular: metoroclustertelemetryrule
+    shortNames:
+      - mctelrule
+      - mctelrules
+    categories:
+      - metoro
+      - metoro-rbac
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Groups
+          type: string
+          jsonPath: .spec.groups
+        - name: Rules
+          type: string
+          jsonPath: .spec.rules[*].signals
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: MetoroClusterTelemetryRule grants Metoro groups access to telemetry from the cluster where the rule is created.
+          required:
+            - spec
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - groups
+                - rules
+              properties:
+                groups:
+                  type: array
+                  description: Metoro groups this rule grants telemetry visibility to.
+                  minItems: 1
+                  maxItems: 256
+                  x-kubernetes-list-type: set
+                  items:
+                    type: string
+                    minLength: 1
+                    maxLength: 256
+                rules:
+                  type: array
+                  description: Allow-expressions whose effective access is the union of all entries.
+                  minItems: 1
+                  maxItems: 256
+                  items:
+                    type: object
+                    required:
+                      - signals
+                    properties:
+                      signals:
+                        type: array
+                        description: Telemetry signals this grant covers.
+                        minItems: 1
+                        maxItems: 5
+                        x-kubernetes-list-type: set
+                        items:
+                          type: string
+                          enum:
+                            - logs
+                            - metrics
+                            - traces
+                            - profiles
+                            - kubernetesResources
+                      match:
+                        type: object
+                        description: Optional telemetry attribute selector that narrows the inherited cluster scope.
+                        properties:
+                          matchExpressions:
+                            type: array
+                            description: Attribute match expressions. Expressions are ANDed within a rule.
+                            maxItems: 64
+                            items:
+                              type: object
+                              required:
+                                - key
+                                - operator
+                              x-kubernetes-validations:
+                                - rule: "self.operator in ['Exists', 'DoesNotExist'] ? !has(self.values) : (has(self.values) && size(self.values) > 0)"
+                                  message: values must be set for In, NotIn, and RegexIn, and omitted for Exists and DoesNotExist.
+                              properties:
+                                key:
+                                  type: string
+                                  description: Telemetry attribute key, such as service.name, namespace, severity, metric.name, status.code, or a custom attribute.
+                                  minLength: 1
+                                  maxLength: 256
+                                operator:
+                                  type: string
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    - RegexIn
+                                values:
+                                  type: array
+                                  description: Values for In, NotIn, and RegexIn operators.
+                                  maxItems: 256
+                                  x-kubernetes-list-type: set
+                                  items:
+                                    type: string
+                                    maxLength: 1024

--- a/charts/metoro-exporter/crds/rbac.metoro.io_metoronamespaceresourcerules.yaml
+++ b/charts/metoro-exporter/crds/rbac.metoro.io_metoronamespaceresourcerules.yaml
@@ -1,0 +1,108 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: metoronamespaceresourcerules.rbac.metoro.io
+spec:
+  group: rbac.metoro.io
+  names:
+    kind: MetoroNamespaceResourceRule
+    listKind: MetoroNamespaceResourceRuleList
+    plural: metoronamespaceresourcerules
+    singular: metoronamespaceresourcerule
+    shortNames:
+      - mnresrule
+      - mnresrules
+    categories:
+      - metoro
+      - metoro-rbac
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Groups
+          type: string
+          jsonPath: .spec.groups
+        - name: Resources
+          type: string
+          jsonPath: .spec.rules[*].resources
+        - name: Verbs
+          type: string
+          jsonPath: .spec.rules[*].verbs
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: MetoroNamespaceResourceRule grants Metoro groups access to Metoro resources from the namespace where the rule is created.
+          required:
+            - spec
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - groups
+                - rules
+              properties:
+                groups:
+                  type: array
+                  description: Metoro groups this rule grants resource permissions to.
+                  minItems: 1
+                  maxItems: 256
+                  x-kubernetes-list-type: set
+                  items:
+                    type: string
+                    minLength: 1
+                    maxLength: 256
+                rules:
+                  type: array
+                  description: Allow-grants whose effective access is the union of all entries.
+                  minItems: 1
+                  maxItems: 256
+                  items:
+                    type: object
+                    required:
+                      - resources
+                      - verbs
+                    properties:
+                      resources:
+                        type: array
+                        description: Metoro resource types this grant covers.
+                        minItems: 1
+                        maxItems: 7
+                        x-kubernetes-list-type: set
+                        items:
+                          type: string
+                          enum:
+                            - dashboards
+                            - alerts
+                            - webhooks
+                            - ingestionFilters
+                            - redactionRules
+                            - aiWorkflowSettings
+                            - "*"
+                      verbs:
+                        type: array
+                        description: Actions this grant allows.
+                        minItems: 1
+                        maxItems: 4
+                        x-kubernetes-list-type: set
+                        items:
+                          type: string
+                          enum:
+                            - create
+                            - read
+                            - update
+                            - delete
+                      path:
+                        type: string
+                        description: Optional relative subpath that narrows the inherited namespace resource scope.
+                        maxLength: 1024

--- a/charts/metoro-exporter/crds/rbac.metoro.io_metoronamespaceresourcerules.yaml
+++ b/charts/metoro-exporter/crds/rbac.metoro.io_metoronamespaceresourcerules.yaml
@@ -77,24 +77,14 @@ spec:
                         type: array
                         description: Metoro resource types this grant covers.
                         minItems: 1
-                        maxItems: 13
+                        maxItems: 3
                         x-kubernetes-list-type: set
                         items:
                           type: string
                           enum:
-                            - billing
-                            - dashboards
                             - alerts
-                            - environments
-                            - logFilters
-                            - traceRedacts
-                            - integrations
-                            - workflows
-                            - accessManagement
-                            - investigations
-                            - apiKeys
-                            - memories
-                            - "*"
+                            - dashboards
+                            - webhooks
                       verbs:
                         type: array
                         description: Actions this grant allows.

--- a/charts/metoro-exporter/crds/rbac.metoro.io_metoronamespaceresourcerules.yaml
+++ b/charts/metoro-exporter/crds/rbac.metoro.io_metoronamespaceresourcerules.yaml
@@ -77,17 +77,23 @@ spec:
                         type: array
                         description: Metoro resource types this grant covers.
                         minItems: 1
-                        maxItems: 7
+                        maxItems: 13
                         x-kubernetes-list-type: set
                         items:
                           type: string
                           enum:
+                            - billing
                             - dashboards
                             - alerts
-                            - webhooks
-                            - ingestionFilters
-                            - redactionRules
-                            - aiWorkflowSettings
+                            - environments
+                            - logFilters
+                            - traceRedacts
+                            - integrations
+                            - workflows
+                            - accessManagement
+                            - investigations
+                            - apiKeys
+                            - memories
                             - "*"
                       verbs:
                         type: array

--- a/charts/metoro-exporter/crds/rbac.metoro.io_metoronamespacetelemetryrules.yaml
+++ b/charts/metoro-exporter/crds/rbac.metoro.io_metoronamespacetelemetryrules.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: metoronamespacetelemetryrules.rbac.metoro.io
+spec:
+  group: rbac.metoro.io
+  names:
+    kind: MetoroNamespaceTelemetryRule
+    listKind: MetoroNamespaceTelemetryRuleList
+    plural: metoronamespacetelemetryrules
+    singular: metoronamespacetelemetryrule
+    shortNames:
+      - mntelrule
+      - mntelrules
+    categories:
+      - metoro
+      - metoro-rbac
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Groups
+          type: string
+          jsonPath: .spec.groups
+        - name: Rules
+          type: string
+          jsonPath: .spec.rules[*].signals
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: MetoroNamespaceTelemetryRule grants Metoro groups access to telemetry from the namespace where the rule is created.
+          required:
+            - spec
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - groups
+                - rules
+              properties:
+                groups:
+                  type: array
+                  description: Metoro groups this rule grants telemetry visibility to.
+                  minItems: 1
+                  maxItems: 256
+                  x-kubernetes-list-type: set
+                  items:
+                    type: string
+                    minLength: 1
+                    maxLength: 256
+                rules:
+                  type: array
+                  description: Allow-expressions whose effective access is the union of all entries.
+                  minItems: 1
+                  maxItems: 256
+                  items:
+                    type: object
+                    required:
+                      - signals
+                    properties:
+                      signals:
+                        type: array
+                        description: Telemetry signals this grant covers.
+                        minItems: 1
+                        maxItems: 5
+                        x-kubernetes-list-type: set
+                        items:
+                          type: string
+                          enum:
+                            - logs
+                            - metrics
+                            - traces
+                            - profiles
+                            - kubernetesResources
+                      match:
+                        type: object
+                        description: Optional telemetry attribute selector that narrows the inherited namespace scope.
+                        properties:
+                          matchExpressions:
+                            type: array
+                            description: Attribute match expressions. Expressions are ANDed within a rule.
+                            maxItems: 64
+                            items:
+                              type: object
+                              required:
+                                - key
+                                - operator
+                              x-kubernetes-validations:
+                                - rule: "self.operator in ['Exists', 'DoesNotExist'] ? !has(self.values) : (has(self.values) && size(self.values) > 0)"
+                                  message: values must be set for In, NotIn, and RegexIn, and omitted for Exists and DoesNotExist.
+                              properties:
+                                key:
+                                  type: string
+                                  description: Telemetry attribute key, such as service.name, namespace, severity, metric.name, status.code, or a custom attribute.
+                                  minLength: 1
+                                  maxLength: 256
+                                operator:
+                                  type: string
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    - RegexIn
+                                values:
+                                  type: array
+                                  description: Values for In, NotIn, and RegexIn operators.
+                                  maxItems: 256
+                                  x-kubernetes-list-type: set
+                                  items:
+                                    type: string
+                                    maxLength: 1024

--- a/charts/metoro-exporter/crds/rbac.metoro.io_metoronamespacetelemetryrules.yaml
+++ b/charts/metoro-exporter/crds/rbac.metoro.io_metoronamespacetelemetryrules.yaml
@@ -86,10 +86,13 @@ spec:
                       match:
                         type: object
                         description: Optional telemetry attribute selector that narrows the inherited namespace scope.
+                        required:
+                          - matchExpressions
                         properties:
                           matchExpressions:
                             type: array
                             description: Attribute match expressions. Expressions are ANDed within a rule.
+                            minItems: 1
                             maxItems: 64
                             items:
                               type: object

--- a/charts/metoro-exporter/templates/exporter_service_account.yaml
+++ b/charts/metoro-exporter/templates/exporter_service_account.yaml
@@ -35,6 +35,9 @@ rules:
   - apiGroups: [ "monitoring.coreos.com" ]
     resources: [ "alertmanagerconfigs", "alertmanagers", "podmonitors", "probes", "prometheusagents", "prometheuses", "prometheusrules", "scrapeconfigs", "servicemonitors", "thanosrulers" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "rbac.metoro.io" ]
+    resources: [ "metoronamespacetelemetryrules", "metoroclustertelemetryrules" ]
+    verbs: [ "get", "list", "watch" ]
 
 ---
 

--- a/charts/metoro-exporter/templates/exporter_service_account.yaml
+++ b/charts/metoro-exporter/templates/exporter_service_account.yaml
@@ -36,7 +36,7 @@ rules:
     resources: [ "alertmanagerconfigs", "alertmanagers", "podmonitors", "probes", "prometheusagents", "prometheuses", "prometheusrules", "scrapeconfigs", "servicemonitors", "thanosrulers" ]
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "rbac.metoro.io" ]
-    resources: [ "metoronamespacetelemetryrules", "metoroclustertelemetryrules" ]
+    resources: [ "metoronamespacetelemetryrules", "metoroclustertelemetryrules", "metoronamespaceresourcerules", "metoroclusterresourcerules" ]
     verbs: [ "get", "list", "watch" ]
 
 ---

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -18,7 +18,7 @@ exporter:
       apiServerUrl: "https://us-east.metoro.io/api/v1/exporter"
       shouldDropMetoroData: "true"
     optional:
-      # Comma-separated selectors for Kubernetes resources to watch (for example: "pod,service,deployment,ingress").
+      # Comma-separated selectors for Kubernetes resources to watch (for example: "pod,service,deployment,ingress,metoro-namespace-telemetry-rule,metoro-namespace-resource-rule").
       # Leave empty to watch all exporter-supported resources.
       k8sResources: ""
     userDefined: {}


### PR DESCRIPTION
## High level goal

Add the Metoro RBAC 2.0 telemetry and resource rule CRDs to the public SaaS exporter Helm chart so new SaaS onboarding installs can create the Kubernetes resource types required by the exporter.

## Desired behaviour

New installs of the `metoro-exporter` chart should install `MetoroNamespaceTelemetryRule`, `MetoroClusterTelemetryRule`, `MetoroNamespaceResourceRule`, and `MetoroClusterResourceRule` CRDs automatically from the chart `crds/` directory. The exporter ServiceAccount should be able to `get`, `list`, and `watch` all four resources so the exporter can send them through the existing Kubernetes resource update pipeline once the matching exporter image is deployed.

ResourceRule CRDs should accept only `alerts`, `dashboards`, and `webhooks` in `rules[].resources`.

## How it was achieved

- Added all four `rbac.metoro.io/v1alpha1` CRDs under `charts/metoro-exporter/crds/`.
- Added exporter ClusterRole read permissions for both telemetry rule and resource rule CRDs.
- Updated both ResourceRule CRD schemas to restrict `rules[].resources` to `alerts`, `dashboards`, and `webhooks`.
- Bumped the chart patch version from `0.473.1` to `0.473.3`.

## Validation

- `helm dependency build charts/metoro-exporter`
- `helm lint charts/metoro-exporter`
- `helm template metoro-exporter charts/metoro-exporter --include-crds`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' charts/metoro-exporter/crds/rbac.metoro.io_metoronamespaceresourcerules.yaml charts/metoro-exporter/crds/rbac.metoro.io_metoroclusterresourcerules.yaml`
- Confirmed rendered CRDs include the two telemetry rule CRDs and the two resource rule CRDs.
- Confirmed rendered ResourceRule CRDs use `maxItems: 3`, include `webhooks`, and no longer include broad resource values or `*`.
- Confirmed rendered ClusterRole includes the `rbac.metoro.io` read rule for all four resources.
