### PR TITLE
Avoid managing exporter replicas when HPA is enabled

### DIFF
--- a/charts/metoro-exporter/Chart.yaml
+++ b/charts/metoro-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the Metoro Exporter
 
 type: application
 
-version: 0.474.0
+version: 0.474.1
 appVersion: 0.2303.0
 
 

--- a/charts/metoro-exporter/templates/exporter_deployment.yaml
+++ b/charts/metoro-exporter/templates/exporter_deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- toYaml .Values.exporter.metadata.selectorLabels | nindent 4 }}
 spec:
+  {{- if not .Values.exporter.autoscaling.horizontalPodAutoscaler.enabled }}
   replicas: {{ .Values.exporter.replicas }}
+  {{- end }}
   strategy:
     {{- toYaml .Values.exporter.updateStrategy | nindent 4 }}
   selector:

--- a/charts/metoro-exporter/values.yaml
+++ b/charts/metoro-exporter/values.yaml
@@ -5,6 +5,7 @@ exporter:
     podAnnotations: {}
     selectorLabels:
       app.kubernetes.io/name: "metoro-exporter"
+  # Used only when the horizontal pod autoscaler is disabled.
   replicas: 2
   updateStrategy:
     type: "RollingUpdate"


### PR DESCRIPTION
## Summary

- omit `Deployment.spec.replicas` when the exporter HPA is enabled
- retain `exporter.replicas` behavior when autoscaling is disabled
- clarify the value's scope and bump the chart patch version to `0.474.1`

## Why

The chart currently enables the exporter HPA by default while also rendering `spec.replicas: 2`. When the HPA changes the replica count, GitOps reconcilers such as Argo CD detect drift and restore the chart value, causing the Deployment to flap between the HPA-selected count and two replicas.

With this change, the HPA exclusively manages the replica field whenever it is enabled.

## Upgrade impact

Existing resources are updated in place. Installations using client-side apply should account for Kubernetes' one-time migration behavior when a previously managed `spec.replicas` field is removed: it can briefly default to one before the HPA reconciles it. To avoid that transition, remove `spec.replicas` from the Deployment's last-applied configuration before syncing this chart version.

Installations with the HPA disabled are unchanged and continue to render the configured `exporter.replicas` value.

## Validation

- `git diff --check`
- `helm lint`
- verified the default HPA-enabled render omits `spec.replicas`
- verified an HPA-disabled render with `exporter.replicas=4` emits `replicas: 4`
