### PR TITLE
Remove GOMAXPROCS env from the node-agent daemonset

### DIFF
--- a/charts/metoro-exporter/templates/node_agent_daemonset.yaml
+++ b/charts/metoro-exporter/templates/node_agent_daemonset.yaml
@@ -51,11 +51,6 @@ spec:
           resources:
             {{- toYaml .Values.nodeAgent.resources | nindent 12 }}
           env:
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                 resource: limits.cpu
-                 divisor: "1"
             - name: DISABLE_LOG_PARSING
               value: {{ printf "\"%t\"" (not .Values.nodeAgent.logExport.enabled) }}
             - name: TRACES_ENDPOINT


### PR DESCRIPTION
## ⚠️ Hold — merge after node-agent change is in the deployed agent image

The node-agent now derives GOMAXPROCS from its cgroup CPU quota in-process, matching Go 1.25's container-aware default (`max(2, ceil(quota))`, capped at host cores). The chart's Downward API env var always takes precedence over the in-process derivation.

Differences vs the env var this removes:

- **Floor of 2 instead of 1** — a 500m CPU limit gave `GOMAXPROCS=1` via `resourceFieldRef`; single-P Go programs have known pathologies under load.
- **Correct no-limit handling** — with no CPU limit set, `resourceFieldRef: limits.cpu` falls back to node allocatable, pinning the env var to host cores; the in-process derivation is a clean no-op instead.
- **One source of truth** — the same logic also covers non-helm installs.

Rendered with `helm template` to confirm the remaining env block is intact.